### PR TITLE
feat: enable Fat LTO and codegen-units = 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,5 @@ regex = { version = "1.6.0", default-features = false }
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+codegen-units = 1
+lto = "fat"


### PR DESCRIPTION
As was proposed in https://github.com/untitaker/quickenv/issues/20#issuecomment-2631814317 - I did the corresponding PR.

At my machine (AMD Ryzen 9 5900x, Fedora 41, Rustc 1.84.1, `cargo build --profile dist`), this change reduces the binary size from 1.6 Mib to 1.3 Mib. Build time increase is from 6s to 10s.